### PR TITLE
Call the previous tab transformer

### DIFF
--- a/src/main/java/de/lemaik/chunky/denoiser/DenoiserPlugin.java
+++ b/src/main/java/de/lemaik/chunky/denoiser/DenoiserPlugin.java
@@ -32,6 +32,7 @@ public class DenoiserPlugin implements Plugin {
 
         RenderControlsTabTransformer prev = chunky.getRenderControlsTabTransformer();
         chunky.setRenderControlsTabTransformer(tabs -> {
+            tabs = prev.apply(tabs);
             tabs.add(DenoiserTab.getImplementation());
             return tabs;
         });


### PR DESCRIPTION
To not overwrite the tab transformer of another plugin that also want to add a new tab.
(made with the online interface of github, hope there isn't an error in this single line)