### PR TITLE
Typo

### DIFF
--- a/src/main/java/de/lemaik/chunky/denoiser/BetterRenderManager.java
+++ b/src/main/java/de/lemaik/chunky/denoiser/BetterRenderManager.java
@@ -65,7 +65,7 @@ public class BetterRenderManager extends RenderManager {
                         try (OutputStream out = new BufferedOutputStream(context.getSceneFileOutputStream(scene.name + ".pfm"))) {
                           writePfmImage(out, true);
                         } catch (IOException e) {
-                          Log.error("Saving the albedo PFM failed", e);
+                          Log.error("Saving the render PFM failed", e);
                         }
 
                         String denoiserPath = PersistentSettings.settings.getString("oidnPath", null);


### PR DESCRIPTION
Render save as PFM logs errors as "albedo" instead of "render".
(correct me if I'm wrong)